### PR TITLE
quote path

### DIFF
--- a/lib/gitdocs/runner.rb
+++ b/lib/gitdocs/runner.rb
@@ -134,7 +134,7 @@ module Gitdocs
     def sh_with_code(cmd)
       cmd << " 2>&1"
       outbuf = ''
-      outbuf = `cd #{@root} && #{cmd}`
+      outbuf = `cd "#{@root}" && #{cmd}`
       [outbuf, $?]
     end
   end


### PR DESCRIPTION
Quote the root path, so that e.g. "~/Library/Application Support/..." works as a path in sh_with_code()
