### PR TITLE
Allignment Issue with Code Blocks

### DIFF
--- a/lib/gitdocs/public/css/tilt.css
+++ b/lib/gitdocs/public/css/tilt.css
@@ -21,7 +21,7 @@ body .contents .tilt {
 
 .tilt code {
   background-color: #eee;
-  padding: 1px 3px;
+  padding: 0;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;


### PR DESCRIPTION
Code blocks are not aligned due to padding. Tested in Safari, Chrome and Firefox.

![](https://img.skitch.com/20120105-f1n2aeec4ts5436infhekqyarp.png)
