### PR TITLE
Add optional git commit message field to the edit form.

### DIFF
--- a/lib/gitdocs/runner.rb
+++ b/lib/gitdocs/runner.rb
@@ -109,10 +109,16 @@ module Gitdocs
     end
 
     def push_changes
+      message_file = File.expand_path(".gitmessage~", @root)
+      if File.exist? message_file
+        message = File.read message_file
+        File.delete message_file
+      else
+        message = 'Auto-commit from gitdocs'
+      end
       sh 'find . -type d -regex ``./[^.].*'' -empty -exec touch \'{}/.gitignore\' \;'
       sh 'git add .'
-      # TODO make this message nicer
-      sh "git commit -a -m'Auto-commit from gitdocs'" unless sh("git status -s").strip.empty?
+      sh "git commit -a -m #{ShellTools.escape(message)}" unless sh("git status -s").strip.empty?
       if @current_revision.nil? || sh('git status')[/branch is ahead/]
         out, code = sh_with_code("git push #{@current_remote} #{@current_branch}")
         if code.success?

--- a/lib/gitdocs/server.rb
+++ b/lib/gitdocs/server.rb
@@ -68,6 +68,7 @@ module Gitdocs
               file_path = URI.unescape(request.path_info)
               file_ext  = File.extname(file_path)
               expanded_path = File.expand_path(".#{file_path}", gd.root)
+              message_file = File.expand_path(".gitmessage~", gd.root)
               halt 400 unless expanded_path[/^#{Regexp.quote(gd.root)}/]
               parent = File.dirname(file_path)
               parent = '' if parent == '/'
@@ -79,6 +80,7 @@ module Gitdocs
                 halt 200, { 'Content-Type' => 'application/json' }, [gd.file_meta(file_path).to_json]
               elsif mode == 'save' # Saving
                 File.open(expanded_path, 'w') { |f| f.print request.params['data'] }
+                File.open(message_file, 'w') { |f| f.print request.params['message'] } unless request.params['message'] == ''
                 redirect! "/" + idx.to_s + file_path
               elsif mode == 'upload'  # Uploading
                 halt 404 unless file = request.params['file']

--- a/lib/gitdocs/views/edit.haml
+++ b/lib/gitdocs/views/edit.haml
@@ -5,6 +5,8 @@
 %form{ :class => "edit", :action => "/#{idx}#{request.path_info}?mode=save", :method => "post", :style => "display:none;" }
   #editor
   %textarea{ :id => 'data', :name => "data" }= preserve contents
+  .clearfix
+    %textarea{ :id => 'message', :name => 'message', :class => 'span16', :placeholder => 'Optional commit message.' }
   %input{ :type => 'submit', :value => "Save", :class => "btn primary" }
   %a{ :href => "/#{idx}#{request.path_info}", :class => "btn secondary" } Cancel
   %input{ :type => 'hidden', :class => 'filename', :value => request.path_info }


### PR DESCRIPTION
The message is stored in a temporary `.gitmessage~` file in the root of the repository.
The file contents are read and set as the commit message.
If the file doesn't exist (the message field was left blank), then the default commit message is used.
