### PR TITLE
Add missing dependency on bigdecimal for ruby 1.9.3. Solves: /usr/share/...

### DIFF
--- a/gitdocs.gemspec
+++ b/gitdocs.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'shell_tools', "~> 0.1.0"
   s.add_dependency 'mimetype-fu', "~> 0.1.2"
   s.add_dependency 'eventmachine', '>= 1.0.0.beta.3'
+  s.add_dependency 'bigdecimal', '~> 1.1.0'
 
   s.add_development_dependency 'minitest', "~> 2.6.1"
   s.add_development_dependency 'rake'


### PR DESCRIPTION
...rubygems/rubygems/custom_require.rb:36:in `require': cannot load such file -- bigdecimal (LoadError)
