### PR TITLE
Minor css change to fix ordered lists

### DIFF
--- a/lib/gitdocs/public/css/tilt.css
+++ b/lib/gitdocs/public/css/tilt.css
@@ -40,10 +40,6 @@ body .contents .tilt {
   margin: 0.3em;
 }
 
-.tilt li {
-  list-style-type: square;
-}
-
 .tilt a:link, .tilt a:visited{
   color: #33e;
   text-decoration: none;


### PR DESCRIPTION
I removed the tilt li block that was overriding default behavior for ordered lists with square bullets.
