### PR TITLE
Dropping support for ruby1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - ruby-head

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ synchronized across all gitdocs-enabled clients.
 
 ## Installation
 
-Requires ruby and rubygems. Install as a gem:
+Requires ruby1.9+ and rubygems. Install as a gem:
 
 ```
 gem install gitdocs

--- a/gitdocs.gemspec
+++ b/gitdocs.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = '>= 1.9'
+
   s.add_dependency 'joshbuddy-guard', '~> 0.10.0'
   s.add_dependency 'thin', '~> 1.5.1'
   s.add_dependency 'renee', '~> 0.3.11'
@@ -40,8 +42,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'fakeweb'
-
-  if RUBY_VERSION > '1.9'
-    s.add_development_dependency 'metric_fu'
-  end
+  s.add_development_dependency 'metric_fu'
 end


### PR DESCRIPTION
This is motivated by a failing test suite in TravisCI, but it seems
reasonable given that ruby2.0 is already out.

It will also allow us to make use of ruby1.9 features without worrying
about backwards compatibility.
