### PR TITLE
Fix the file system watch status

### DIFF
--- a/lib/gitdocs/cli.rb
+++ b/lib/gitdocs/cli.rb
@@ -135,20 +135,15 @@ module Gitdocs
 
       # @return [Symbol] to indicate how the file system is being watched
       def file_system_watch_method
-        if Guard::Listener.mac?
-          begin
-            return :notification if Guard::Listener::Darwin.usable?
-          rescue NameError ; end
-        elsif Guard::Listener.linux?
-          begin
-            return :notification if Guard::Listener::Linux.usable?
-          rescue NameError ; end
-        elsif Guard::Listener.windows?
-          begin
-            return :notification if Guard::Listener::Windows.usable?
-          rescue NameError ; end
+        if Guard::Listener.mac? && Guard::Darwin.usable?
+          :notification
+        elsif Guard::Listener.linux? && Guard::Linux.usable?
+          :notification
+        elsif Guard::Listener.windows? && Guard::Windows.usable?
+          :notification
+        else
+          :polling
         end
-        :polling
       end
     end
   end


### PR DESCRIPTION
I just did it wrong in my original commit 09bae4
I mis-understood now the Guard::Listener classes worked, and assumed
that the NameError exception was an expected response.

Fixed, cleaned up the if block and removed the now unnecessary rescue
blocks.
