### PR TITLE
Working on removing the extra file changes and extra notifications

### DIFF
--- a/lib/gitdocs/repository.rb
+++ b/lib/gitdocs/repository.rb
@@ -192,7 +192,7 @@ class Gitdocs::Repository
 
     #add and commit
     Dir.glob(File.join(root, '**', '*'))
-      .select { |x| File.directory?(x) && Dir.glob("#{x}/*").empty? }
+      .select { |x| File.directory?(x) && Dir.glob("#{x}/*", File::FNM_DOTMATCH).size == 2 }
       .each { |x| FileUtils.touch(File.join(x, '.gitignore')) }
     Dir.chdir(root) do
       @rugged.index.add_all


### PR DESCRIPTION
I hope that this PR will help to address #77 and the file churn and the extra notify activity that @quite is seeing with 0.5-pre3. The problems that I have seen so far:
- .gitignore files in empty directories were getting written over and over again (fixed)
- index is getting written unnecessarily

Starting the PR so that everyone else can see what I have so far. I'll be looking into how the check the index writes in the test next.
