### PR TITLE
Remove the load_browser_on_startup config option

### DIFF
--- a/lib/gitdocs/configuration.rb
+++ b/lib/gitdocs/configuration.rb
@@ -21,7 +21,7 @@ module Gitdocs
     end
 
     class Config < ActiveRecord::Base
-      attr_accessible :load_browser_on_startup, :start_web_frontend, :web_frontend_port
+      attr_accessible :start_web_frontend, :web_frontend_port
     end
 
     def add_path(path, opts = nil)

--- a/lib/gitdocs/views/settings.haml
+++ b/lib/gitdocs/views/settings.haml
@@ -8,11 +8,6 @@
       %dt Web Frontend Port
       %dd
         %input{:type =>'input', :name=>"config[web_frontend_port]", :value => conf.global.web_frontend_port }
-    %p
-      %input{:type =>'hidden', :value => '0', :name=>"config[load_browser_on_startup]"}
-      %input{:type =>'checkbox', :value => '1', :name=>"config[load_browser_on_startup]", :checked => conf.global.load_browser_on_startup ? 'checked' : nil}
-      %span Open browser on startup?
-
   %h2 Shares
   - conf.shares.each_with_index do |share, idx|
     %div{:id => "share-#{idx}", :class => "share #{idx % 2 == 0 ? 'even' : 'odd'}"}

--- a/test/integration/full_sync_test.rb
+++ b/test/integration/full_sync_test.rb
@@ -9,7 +9,6 @@ describe 'fully synchronizing repositories' do
     configuration.shares.each do |share|
       share.update_attributes(polling_interval: 0.1, notification: false)
     end
-    configuration.global.update_attributes(load_browser_on_startup: false)
 
     start_cmd = 'gitdocs start --debug --pid=gitdocs.pid --port 7777'
     run(start_cmd, 15)


### PR DESCRIPTION
We stopped using this a few commits ago, so finishing up that change
and removing it completely.
