### PR TITLE
Refactoring to simplify database access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
+sudo: false

--- a/bin/gitdocs
+++ b/bin/gitdocs
@@ -2,4 +2,5 @@
 
 require 'gitdocs'
 
+Gitdocs::Initializer.initialize_all
 Gitdocs::Cli.start(ARGV)

--- a/config.ru
+++ b/config.ru
@@ -10,12 +10,12 @@ use Rack::Static,
   root: './lib/gitdocs/public'
 use Rack::MethodOverride
 
-config_root = './tmp/web'
-FileUtils.mkdir_p(config_root)
-Gitdocs::SettingsApp.set :manager, Gitdocs::Manager.new(config_root, true)
+Gitdocs::Initializer.root_dirname = './tmp/web'
+Gitdocs::Initializer.initialize_database
+
 Gitdocs::SettingsApp.set :logging, true
 map('/settings') { run Gitdocs::SettingsApp }
 
-Gitdocs::BrowserApp.set :repositories, Gitdocs::Configuration.new(config_root).shares.map { |x| Gitdocs::Repository.new(x) }
+Gitdocs::BrowserApp.set :repositories, Gitdocs::Share.all.map { |x| Gitdocs::Repository.new(x) }
 Gitdocs::BrowserApp.set :logging, true
 map('/') { run Gitdocs::BrowserApp }

--- a/gitdocs.gemspec
+++ b/gitdocs.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'fakeweb'
   s.add_development_dependency 'metric_fu'
-  s.add_development_dependency 'aruba'
+  s.add_development_dependency 'aruba',                  '~> 0.6.1'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'haml-lint',              '~> 0.10.0'
   s.add_development_dependency 'jslint_on_rails',        '~> 1.1.1'

--- a/lib/gitdocs.rb
+++ b/lib/gitdocs.rb
@@ -10,6 +10,8 @@ require 'rugged'
 require 'table_print'
 
 require 'gitdocs/version'
+require 'gitdocs/initializer'
+require 'gitdocs/share'
 require 'gitdocs/configuration'
 require 'gitdocs/runner'
 require 'gitdocs/server'

--- a/lib/gitdocs.rb
+++ b/lib/gitdocs.rb
@@ -23,14 +23,11 @@ require 'gitdocs/repository/path'
 require 'gitdocs/search'
 
 module Gitdocs
-  DEBUG = ENV['DEBUG']
-
-  # Gitdocs.start(:config_root => "...", :debug => true)
-  def self.start(options = {})
-    options = { debug: DEBUG, config_root: nil }.merge(options)
+  # @param [nil, Integer] override_web_port
+  def self.start(override_web_port)
     @manager.stop if @manager
-    @manager = Manager.new(options[:config_root], options[:debug])
-    @manager.start(options[:port])
+    @manager = Manager.new
+    @manager.start(override_web_port)
   end
 
   def self.restart

--- a/lib/gitdocs.rb
+++ b/lib/gitdocs.rb
@@ -26,10 +26,10 @@ module Gitdocs
   DEBUG = ENV['DEBUG']
 
   # Gitdocs.start(:config_root => "...", :debug => true)
-  def self.start(options = {}, &blk)
+  def self.start(options = {})
     options = { debug: DEBUG, config_root: nil }.merge(options)
     @manager.stop if @manager
-    @manager = Manager.new(options[:config_root], options[:debug], &blk)
+    @manager = Manager.new(options[:config_root], options[:debug])
     @manager.start(options[:port])
   end
 

--- a/lib/gitdocs.rb
+++ b/lib/gitdocs.rb
@@ -20,6 +20,8 @@ require 'gitdocs/manager'
 require 'gitdocs/notifier'
 require 'gitdocs/repository'
 require 'gitdocs/repository/path'
+require 'gitdocs/repository/invalid_error'
+require 'gitdocs/repository/committer'
 require 'gitdocs/search'
 
 module Gitdocs

--- a/lib/gitdocs.rb
+++ b/lib/gitdocs.rb
@@ -37,4 +37,17 @@ module Gitdocs
   def self.stop
     @manager.stop
   end
+
+  # @return [Logger]
+  def self.logger
+    return @logger if @logger
+
+    output =
+      if Initializer::debug
+        STDOUT
+      else
+        File.expand_path('log', Initializer.root_dirname)
+      end
+    @logger = Logger.new(output)
+  end
 end

--- a/lib/gitdocs/browser_app.rb
+++ b/lib/gitdocs/browser_app.rb
@@ -30,7 +30,7 @@ module Gitdocs
       haml(
         :search,
         locals: {
-          results: Search.new(settings.repositories).search(params[:q]),
+          results:   Search.search(params[:q]),
           nav_state: nil
         }
       )

--- a/lib/gitdocs/browser_app.rb
+++ b/lib/gitdocs/browser_app.rb
@@ -20,7 +20,7 @@ module Gitdocs
 
       # @return [Gitdocs::Repository::Path]
       def repository
-        @repository ||= Repository.new(Share.at(id))
+        @repository ||= Repository.new(Share.find(id))
       end
 
       # @return [Gitdocs::Repository::Path]
@@ -34,7 +34,7 @@ module Gitdocs
 
     get('/') do
       if Share.all.count == 1
-        redirect to('/0/')
+        redirect to("/#{Share.first.id}/")
       else
         haml(:home, locals: { nav_state: 'home' })
       end
@@ -52,7 +52,6 @@ module Gitdocs
 
     get('/:id*') do
       default_locals = {
-        idx:       id,
         root:      repository.root,
         nav_state: nil
       }

--- a/lib/gitdocs/browser_app.rb
+++ b/lib/gitdocs/browser_app.rb
@@ -10,7 +10,7 @@ module Gitdocs
   class BrowserApp < Sinatra::Base
     set :haml, format: :html5
 
-    helpers Gitdocs::RenderingHelper
+    helpers RenderingHelper
 
     get('/') do
       if settings.repositories.size == 1
@@ -30,7 +30,7 @@ module Gitdocs
       haml(
         :search,
         locals: {
-          results: Gitdocs::Search.new(settings.repositories).search(params[:q]),
+          results: Search.new(settings.repositories).search(params[:q]),
           nav_state: nil
         }
       )
@@ -45,7 +45,7 @@ module Gitdocs
       # @return [Gitdocs::Repository::Path]
       def path
         halt(404) unless settings.repositories[id]
-        @path ||= Gitdocs::Repository::Path.new(
+        @path ||= Repository::Path.new(
           settings.repositories[id], URI.unescape(params[:splat].first)
         )
       end

--- a/lib/gitdocs/browser_app.rb
+++ b/lib/gitdocs/browser_app.rb
@@ -123,18 +123,16 @@ module Gitdocs
     end
 
     put('/:id*') do
-      redirect_path =
+      commit_message =
         if params[:revision] # revert
           path.revert(params[:revision])
-          "/#{id}/#{path.relative_path}"
+          "Reverting '#{path.relative_path}' to #{params[:revision]}"
         elsif params[:data] && params[:message] # save
-          path.write(params[:data], params[:message])
-          "/#{id}/#{path.relative_path}"
-        else
-          # No valid inputs, do nothing and redirect.
-          "/#{id}/#{path.relative_path}"
+          path.write(params[:data])
+          params[:message]
         end
-      redirect to(redirect_path)
+      repository.write_commit_message(commit_message)
+      redirect to("/#{id}/#{path.relative_path}")
     end
 
     delete('/:id*') do

--- a/lib/gitdocs/cli.rb
+++ b/lib/gitdocs/cli.rb
@@ -24,9 +24,10 @@ module Gitdocs
 
       if options[:debug]
         say 'Starting in debug mode', :yellow
-        Gitdocs.start(debug: true, port: options[:port])
+        Gitdocs::Initializer.debug = true
+        Gitdocs.start(options[:port])
       else
-        runner.execute { Gitdocs.start(port: options[:port]) }
+        runner.execute { Gitdocs.start(options[:port]) }
         if running?
           say 'Started gitdocs', :green
         else

--- a/lib/gitdocs/cli.rb
+++ b/lib/gitdocs/cli.rb
@@ -79,7 +79,7 @@ module Gitdocs
     method_option :pid, type: :string, aliases: '-P'
     desc 'create PATH REMOTE', 'Creates a new gitdoc root based on an existing remote'
     def create(path, remote)
-      Gitdocs::Repository.clone(path, remote)
+      Repository.clone(path, remote)
       add(path)
       say "Created #{path} path for gitdoc"
     end
@@ -93,7 +93,7 @@ module Gitdocs
       say 'Watched repositories:'
       tp.set(:max_width, 100)
       status_display = lambda do |share|
-        repository = Gitdocs::Repository.new(share)
+        repository = Repository.new(share)
 
         status = ''
         status += '*' if repository.dirty?

--- a/lib/gitdocs/configuration.rb
+++ b/lib/gitdocs/configuration.rb
@@ -1,112 +1,36 @@
 # -*- encoding : utf-8 -*-
 
 require 'active_record'
-require 'grit'
 
 class Gitdocs::Configuration
-  attr_reader :config_root
-
-  def initialize(config_root = nil)
-    @config_root = config_root || File.expand_path('.gitdocs', ENV['HOME'])
-    FileUtils.mkdir_p(@config_root)
-    ActiveRecord::Base.establish_connection(
-      adapter: 'sqlite3',
-      database: ENV['TEST'] ? ':memory:' : File.join(@config_root, 'config.db')
-    )
-    ActiveRecord::Migrator.migrate(File.expand_path('../migration', __FILE__))
-    import_old_shares unless ENV['TEST']
-  end
-
-  class Share < ActiveRecord::Base
-    #attr_accessible :polling_interval, :path, :notification, :branch_name, :remote_name, :sync_type
-  end
-
-  class Config < ActiveRecord::Base
-    #attr_accessible :start_web_frontend, :web_frontend_port
-  end
-
-  # return [Boolean]
-  def start_web_frontend
-    global.start_web_frontend
+  # @return [Boolean]
+  def self.start_web_frontend
+    Config.global.start_web_frontend
   end
 
   # @return [Integer]
-  def web_frontend_port
-    global.web_frontend_port
-  end
-
-  # @param [String] path
-  # @param [Hash] opts
-  def add_path(path, opts = nil)
-    path = normalize_path(path)
-    path_opts = { path: path }
-    path_opts.merge!(opts) if opts
-    Share.new(path_opts).save!
+  def self.web_frontend_port
+    Config.global.web_frontend_port
   end
 
   # @param [Hash] new_config
-  # @option new_config [Hash] 'config'
-  # @option new_config [Array<Hash>] 'share'
-  def update_all(new_config)
-    global.update_attributes(new_config['config'])
-    new_config['share'].each do |index, share_config|
-      # Skip the share update if there is no path specified.
-      next unless share_config['path'] && !share_config['path'].empty?
-
-      # Split the remote_branch into remote and branch
-      remote_branch = share_config.delete('remote_branch')
-      if remote_branch
-        share_config['remote_name'], share_config['branch_name'] = remote_branch.split('/', 2)
-      end
-      shares[index.to_i].update_attributes(share_config)
-    end
+  def self.update(new_config)
+    Config.global.update_attributes(new_config)
   end
 
-  # @param [String] path of the share to remove
-  def remove_path(path)
-    path = normalize_path(path)
-    Share.where(path: path).destroy_all
-  end
+  # NOTE: This record has been kept as a subclass to avoid changing the
+  # database table. There are other ways to achieve this, but this seemed most
+  # clear for now. [2015-06-26 -- acant]
+  class Config < ActiveRecord::Base
+    # attr_accessible :start_web_frontend, :web_frontend_port
 
-  # @param [Integer] id of the share to remove
-  #
-  # @return [true] share was deleted
-  # @return [false] share does not exist
-  def remove_by_id(id)
-    Share.find(id).destroy
-    true
-  rescue ActiveRecord::RecordNotFound
-    false
-  end
-
-  def clear
-    Share.destroy_all
-  end
-
-  def shares
-    Share.all
-  end
-
-  ##############################################################################
-
-  private
-
-  def global
-    fail if Config.all.size > 1
-    Config.create! if Config.all.empty?
-    Config.all.first
-  end
-
-  def normalize_path(path)
-    File.expand_path(path, Dir.pwd)
-  end
-
-  def import_old_shares
-    full_path = File.expand_path('paths', config_root)
-    return unless File.exist?(full_path)
-
-    File.read(full_path).split("\n").each do |path|
-      Share.find_or_create_by_path(path)
+    # @return [Gitdocs::Configuration::Config]
+    def self.global
+      fail if all.size > 1
+      create! if all.empty?
+      all.first
     end
   end
 end
+
+

--- a/lib/gitdocs/initializer.rb
+++ b/lib/gitdocs/initializer.rb
@@ -1,0 +1,63 @@
+# -*- encoding : utf-8 -*-
+
+require 'active_record'
+
+module Gitdocs
+  class Initializer
+    # @return [nil]
+    def self.initialize_all
+      initialize_database
+      initialize_old_paths
+    end
+
+    # @return [nil]
+    def self.initialize_database
+      FileUtils.mkdir_p(root_dirname)
+      ActiveRecord::Base.establish_connection(
+        adapter: 'sqlite3',
+        database: database
+      )
+      ActiveRecord::Migrator.migrate(
+        File.expand_path('../migration', __FILE__)
+      )
+    end
+
+    # @return [nil]
+    def self.initialize_old_paths
+      old_path_dirname = File.expand_path('paths', root_dirname)
+      return unless File.exist?(old_path_dirname)
+
+      File.read(old_path_dirname).split("\n").each do |path|
+        begin
+          Share.create_by_path!(path)
+        rescue # rubocop:disable ExceptionHandling
+          # Nothing to do, because we want the process to keep going.
+        end
+      end
+    end
+
+    # @return [String]
+    def self.root_dirname
+      @root_dirname ||= File.expand_path('.gitdocs', ENV['HOME'])
+    end
+
+    # @param [nil, String] value
+    # @return [nil]
+    def self.root_dirname=(value)
+      return if value.nil?
+      @root_dirname = value
+    end
+
+    # @return [String]
+    def self.database
+      @database ||= File.join(root_dirname, 'config.db')
+    end
+
+    # @param [nil, String] value
+    # @return [nil]
+    def self.database=(value)
+      return if value.nil?
+      @database = value
+    end
+  end
+end

--- a/lib/gitdocs/initializer.rb
+++ b/lib/gitdocs/initializer.rb
@@ -59,5 +59,15 @@ module Gitdocs
       return if value.nil?
       @database = value
     end
+
+    # @return [Boolean]
+    def self.debug
+      @debug ||= false
+    end
+
+    # @param [Boolean] value
+    def self.debug=(value)
+      @debug = value
+    end
   end
 end

--- a/lib/gitdocs/manager.rb
+++ b/lib/gitdocs/manager.rb
@@ -4,10 +4,7 @@ module Gitdocs
   Restart = Class.new(RuntimeError)
 
   class Manager
-    def initialize
-      @logger = Logger.new(File.expand_path('log', Initializer.root_dirname))
-    end
-
+    # @param [nil, #to_i] override_web_port
     def start(override_web_port)
       log("Starting Gitdocs v#{VERSION}...")
       log("Using configuration root: '#{Initializer.root_dirname}'")
@@ -19,7 +16,7 @@ module Gitdocs
           log('Starting EM loop...')
 
           @runners = Runner.start_all(shares)
-          Server.start_and_wait(self, override_web_port)
+          Server.start_and_wait(override_web_port)
         end
       rescue Restart
         retry
@@ -49,10 +46,14 @@ module Gitdocs
       EM.stop
     end
 
-    # Logs and outputs to file or stdout based on debugging state
-    # log("message")
-    def log(msg, level = :info)
-      Initializer.debug ? puts(msg) : @logger.send(level, msg)
+    ############################################################################
+
+    private
+
+    # @param [String] msg
+    # @return [void]
+    def log(msg)
+      Gitdocs.logger.info(msg)
     end
   end
 end

--- a/lib/gitdocs/manager.rb
+++ b/lib/gitdocs/manager.rb
@@ -13,7 +13,7 @@ module Gitdocs
       yield @config if block_given?
     end
 
-    def start(web_port = nil)
+    def start(override_web_port)
       log("Starting Gitdocs v#{VERSION}...")
       log("Using configuration root: '#{Initializer.root_dirname}'")
       shares = Share.all
@@ -24,8 +24,7 @@ module Gitdocs
           log('Starting EM loop...')
 
           @runners = Runner.start_all(shares)
-          repositories = shares.map { |x| Repository.new(x) }
-          Server.start_and_wait(self, web_port, repositories)
+          Server.start_and_wait(self, override_web_port)
         end
       rescue Restart
         retry

--- a/lib/gitdocs/manager.rb
+++ b/lib/gitdocs/manager.rb
@@ -8,9 +8,8 @@ module Gitdocs
 
     def initialize(config_root, debug)
       Initializer.root_dirname = config_root
-      @logger      = Logger.new(File.expand_path('log', Initializer.root_dirname))
-      @debug       = debug
-      yield @config if block_given?
+      @logger = Logger.new(File.expand_path('log', Initializer.root_dirname))
+      @debug  = debug
     end
 
     def start(override_web_port)

--- a/lib/gitdocs/manager.rb
+++ b/lib/gitdocs/manager.rb
@@ -4,12 +4,8 @@ module Gitdocs
   Restart = Class.new(RuntimeError)
 
   class Manager
-    attr_reader :debug
-
-    def initialize(config_root, debug)
-      Initializer.root_dirname = config_root
+    def initialize
       @logger = Logger.new(File.expand_path('log', Initializer.root_dirname))
-      @debug  = debug
     end
 
     def start(override_web_port)
@@ -56,7 +52,7 @@ module Gitdocs
     # Logs and outputs to file or stdout based on debugging state
     # log("message")
     def log(msg, level = :info)
-      @debug ? puts(msg) : @logger.send(level, msg)
+      Initializer.debug ? puts(msg) : @logger.send(level, msg)
     end
   end
 end

--- a/lib/gitdocs/manager.rb
+++ b/lib/gitdocs/manager.rb
@@ -34,7 +34,7 @@ module Gitdocs
       # Report all errors in log
       log("#{e.class.inspect} - #{e.inspect} - #{e.message.inspect}", :error)
       log(e.backtrace.join("\n"), :error)
-      Gitdocs::Notifier.error(
+      Notifier.error(
         'Unexpected exit',
         'Something went wrong. Please see the log for details.'
       )

--- a/lib/gitdocs/manager.rb
+++ b/lib/gitdocs/manager.rb
@@ -4,18 +4,19 @@ module Gitdocs
   Restart = Class.new(RuntimeError)
 
   class Manager
-    attr_reader :config, :debug
+    attr_reader :debug
 
     def initialize(config_root, debug)
-      @config = Configuration.new(config_root)
-      @logger = Logger.new(File.expand_path('log', @config.config_root))
-      @debug  = debug
+      Initializer.root_dirname = config_root
+      @logger      = Logger.new(File.expand_path('log', Initializer.root_dirname))
+      @debug       = debug
       yield @config if block_given?
     end
 
     def start(web_port = nil)
       log("Starting Gitdocs v#{VERSION}...")
-      log("Using configuration root: '#{config.config_root}'")
+      log("Using configuration root: '#{Initializer.root_dirname}'")
+      shares = Share.all
       log("Shares: (#{shares.length}) #{shares.map(&:inspect).join(', ')}")
 
       begin
@@ -58,29 +59,6 @@ module Gitdocs
     # log("message")
     def log(msg, level = :info)
       @debug ? puts(msg) : @logger.send(level, msg)
-    end
-
-    def start_web_frontend
-      config.start_web_frontend
-    end
-
-    def web_frontend_port
-      config.web_frontend_port
-    end
-
-    def shares
-      config.shares
-    end
-
-    # @see Gitdocs::Configuration#update_all
-    def update_all(new_config)
-      config.update_all(new_config)
-      EM.add_timer(0.1) { restart }
-    end
-
-    # @see Gitdocs::Configuration#remove_by_id
-    def remove_by_id(id)
-      config.remove_by_id(id)
     end
   end
 end

--- a/lib/gitdocs/migration/004_add_index_for_path.rb
+++ b/lib/gitdocs/migration/004_add_index_for_path.rb
@@ -4,7 +4,7 @@
 
 class AddIndexForPath < ActiveRecord::Migration
   def self.up
-    shares = Gitdocs::Configuration::Share.all.reduce(Hash.new { |h, k| h[k] = [] }) { |h, s| h[s.path] << s; h }
+    shares = Gitdocs::Share.all.reduce(Hash.new { |h, k| h[k] = [] }) { |h, s| h[s.path] << s; h }
     shares.each do |path, shares|
       shares.shift
       shares.each(&:destroy) unless shares.empty?

--- a/lib/gitdocs/repository.rb
+++ b/lib/gitdocs/repository.rb
@@ -21,7 +21,7 @@ class Gitdocs::Repository
   # @see #valid?
   # @see #invalid_reason
   #
-  # @param [String, Configuration::Share] path_or_share
+  # @param [String, Share] path_or_share
   def initialize(path_or_share)
     path = path_or_share
     if path_or_share.respond_to?(:path)

--- a/lib/gitdocs/repository.rb
+++ b/lib/gitdocs/repository.rb
@@ -182,28 +182,11 @@ class Gitdocs::Repository
     mark_conflicts
   end
 
-  # Commit the working directory
-  #
-  # @return [nil] if the repository is invalid
-  # @return [Boolean] whether a commit was made or not
+  # @return [nil]
+  # @return (see Gitdocs::Repository::Comitter#commit)
   def commit
-    return nil unless valid?
-
-    # Do this first to allow the message file to be deleted, if it exists.
-    message = read_and_delete_commit_message_file
-
-    mark_empty_directories
-
-    return false unless dirty?
-
-    # Commit any changes in the working directory.
-    Dir.chdir(root) do
-      @rugged.index.add_all
-      @rugged.index.update_all
-    end
-    @rugged.index.write
-    @grit.commit_index(message)
-    true
+    return unless valid?
+    Committer.new(root).commit
   end
 
   # Push the repository
@@ -245,12 +228,11 @@ class Gitdocs::Repository
     {}
   end
 
-  # @param [String] message
+  # @param (see Gitdocs::Repository::Comitter#write_commit_message)
+  # @return [void]
   def write_commit_message(message)
-    return unless message
-    return if message.empty?
-
-    File.open(@commit_message_path, 'w') { |f| f.print(message) }
+    return unless valid?
+    Committer.new(root).write_commit_message(message)
   end
 
   # Excluding the initial commit (without a parent) which keeps things

--- a/lib/gitdocs/repository/committer.rb
+++ b/lib/gitdocs/repository/committer.rb
@@ -1,0 +1,66 @@
+# -*- encoding : utf-8 -*-
+class Gitdocs::Repository::Committer
+  # @raise if the repository is not valid for commits
+  def initialize(root_dirname)
+    @root_dirname        = root_dirname
+    @rugged              = Rugged::Repository.new(root_dirname)
+    @grit                = Grit::Repo.new(root_dirname)
+    @commit_message_path = File.expand_path('.gitmessage~', root_dirname)
+  rescue Rugged::OSError
+    raise(Gitdocs::Repository::InvalidError, 'No directory')
+  rescue Rugged::RepositoryError
+    raise(Gitdocs::Repository::InvalidError, 'Not a repository')
+  end
+
+  # @return [Boolean]
+  def commit
+    # Do this first to allow the message file to be deleted, if it exists.
+    message = read_and_delete_commit_message_file
+
+    mark_empty_directories
+
+    # FIXME: Consider a more appropriate location for the dirty check.
+    return false unless Gitdocs::Repository.new(@root_dirname).dirty?
+
+    # Commit any changes in the working directory.
+    Dir.chdir(@root_dirname) do
+      @rugged.index.add_all
+      @rugged.index.update_all
+    end
+    @rugged.index.write
+    @grit.commit_index(message)
+    true
+  end
+
+  # @param [String] message
+  # @return [void]
+  def write_commit_message(message)
+    return unless message
+    return if message.empty?
+
+    File.open(@commit_message_path, 'w') { |f| f.print(message) }
+  end
+
+  ##########################################################################
+
+  private
+
+  def mark_empty_directories
+    Find.find(@root_dirname).each do |path| # rubocop:disable Style/Next
+      Find.prune if File.basename(path) == '.git'
+      if File.directory?(path) && Dir.entries(path).count == 2
+        FileUtils.touch(File.join(path, '.gitignore'))
+      end
+    end
+  end
+
+  # @return [String] either the message in the file, or the regular
+  #   automatic commit message.
+  def read_and_delete_commit_message_file
+    return 'Auto-commit from gitdocs' unless File.exist?(@commit_message_path)
+
+    message = File.read(@commit_message_path)
+    File.delete(@commit_message_path)
+    message
+  end
+end

--- a/lib/gitdocs/repository/invalid_error.rb
+++ b/lib/gitdocs/repository/invalid_error.rb
@@ -1,0 +1,4 @@
+# -*- encoding : utf-8 -*-
+
+class Gitdocs::Repository::InvalidError < StandardError
+end

--- a/lib/gitdocs/repository/path.rb
+++ b/lib/gitdocs/repository/path.rb
@@ -23,12 +23,10 @@ class Gitdocs::Repository::Path
   # Write the content to the path and create any necessary directories.
   #
   # @param [String] content
-  # @param [String] commit_message
-  def write(content, commit_message)
+  # @return [void]
+  def write(content)
     FileUtils.mkdir_p(File.dirname(@absolute_path))
     File.open(@absolute_path, 'w') { |f| f.puts(content) }
-
-    @repository.write_commit_message(commit_message)
   end
 
   # Touch and path and create any necessary directories.
@@ -147,7 +145,7 @@ class Gitdocs::Repository::Path
     # TODO: should consider throwing an exception on this condition
     return unless blob
 
-    write(blob.text, "Reverting '#{@relative_path}' to #{ref}")
+    write(blob.text)
   end
 
   #############################################################################

--- a/lib/gitdocs/runner.rb
+++ b/lib/gitdocs/runner.rb
@@ -11,8 +11,8 @@ module Gitdocs
     def initialize(share)
       @share = share
       @polling_interval = share.polling_interval
-      @notifier         = Gitdocs::Notifier.new(@share.notification)
-      @repository       = Gitdocs::Repository.new(share)
+      @notifier         = Notifier.new(@share.notification)
+      @repository       = Repository.new(share)
     end
 
     def root

--- a/lib/gitdocs/runner.rb
+++ b/lib/gitdocs/runner.rb
@@ -65,6 +65,8 @@ module Gitdocs
     end
 
     def sync_changes
+      return unless @repository.valid?
+
       # Commit #################################################################
       @repository.commit if @share.sync_type == 'full'
 

--- a/lib/gitdocs/search.rb
+++ b/lib/gitdocs/search.rb
@@ -1,35 +1,50 @@
-class Gitdocs::Search
-  RepoDescriptor = Struct.new(:name, :index)
-  SearchResult   = Struct.new(:file, :context)
+# -*- encoding : utf-8 -*-
 
-  # @param [Array<Gitdocs::Repository>] repositories
-  def initialize(repositories)
-    @repositories = repositories
-  end
+module Gitdocs
+  class Search
+    RepoDescriptor = Struct.new(:name, :index)
+    SearchResult   = Struct.new(:file, :context)
 
-  def search(term)
-    results = {}
-    @repositories.each_with_index do |repository, index|
-      descriptor = RepoDescriptor.new(repository.root, index)
-      results[descriptor] = search_repository(repository, term)
+    # @param [String] term
+    # @return (see #search)
+    def self.search(term)
+      new(Share.all.map { |x| Repository.new(x) }).search(term)
     end
-    results.delete_if { |_key, value| value.empty? }
-  end
 
-  private
+    # @param [Array<Gitdocs::Repository>] repositories
+    def initialize(repositories)
+      @repositories = repositories
+    end
 
-  def search_repository(repository, term)
-    return [] if term.nil? || term.empty?
-
-    results = []
-    repository.grep(term) do |file, context|
-      result = results.find { |s| s.file == file }
-      if result
-        result.context += ' ... ' + context
-      else
-        results << SearchResult.new(file, context)
+    # @param [String] term
+    # @return [Hash<RepoDescriptor, Array<SearchResult>>]
+    def search(term)
+      results = {}
+      @repositories.each_with_index do |repository, index|
+        descriptor = RepoDescriptor.new(repository.root, index)
+        results[descriptor] = search_repository(repository, term)
       end
+      results.delete_if { |_key, value| value.empty? }
     end
-    results
+
+    private
+
+    # @param [Repository] repository
+    # @param [String] term
+    # @return [Array<SearchResult>]
+    def search_repository(repository, term)
+      return [] if term.nil? || term.empty?
+
+      results = []
+      repository.grep(term) do |file, context|
+        result = results.find { |s| s.file == file }
+        if result
+          result.context += ' ... ' + context
+        else
+          results << SearchResult.new(file, context)
+        end
+      end
+      results
+    end
   end
 end

--- a/lib/gitdocs/server.rb
+++ b/lib/gitdocs/server.rb
@@ -6,16 +6,18 @@ require 'gitdocs/settings_app'
 
 module Gitdocs
   class Server
-    def initialize(manager, port)
-      @manager = manager
-      @port    = port.to_i
+    # @param [#to_i] port
+    def initialize(port)
+      @port = port.to_i
     end
 
-    def self.start_and_wait(manager, override_port)
+    # @param [nil, #to_i] override_port
+    # @return [void]
+    def self.start_and_wait(override_port)
       return false unless Configuration.start_web_frontend
 
       web_port = override_port || Configuration.web_frontend_port
-      server = Server.new(manager, web_port)
+      server = Server.new(web_port)
       server.start
       server.wait_for_start
       true
@@ -39,15 +41,15 @@ module Gitdocs
         i = 0
         begin
           TCPSocket.open('127.0.0.1', @port).close
-          @manager.log('Web server running!')
+          Gitdocs.logger.info('Web server running!')
         rescue Errno::ECONNREFUSED
           sleep 0.2
           i += 1
           if i <= 20
-            @manager.log('Retrying web server loop...')
+            Gitdocs.logger.info('Retrying web server loop...')
             retry
           else
-            @manager.log('Web server failed to start')
+            Gitdocs.logger.info('Web server failed to start')
           end
         end
       end

--- a/lib/gitdocs/server.rb
+++ b/lib/gitdocs/server.rb
@@ -14,9 +14,9 @@ module Gitdocs
     end
 
     def self.start_and_wait(manager, override_port, repositories)
-      return false unless manager.start_web_frontend
+      return false unless Configuration.start_web_frontend
 
-      web_port = override_port || manager.web_frontend_port
+      web_port = override_port || Configuration.web_frontend_port
       server = Server.new(manager, web_port, repositories)
       server.start
       server.wait_for_start
@@ -24,7 +24,6 @@ module Gitdocs
     end
 
     def start
-      Gitdocs::SettingsApp.set :manager, @manager
       Gitdocs::BrowserApp.set :repositories, @repositories
 
       Thin::Logging.debug = @manager.debug

--- a/lib/gitdocs/server.rb
+++ b/lib/gitdocs/server.rb
@@ -22,7 +22,7 @@ module Gitdocs
     end
 
     def start
-      Thin::Logging.debug = @manager.debug
+      Thin::Logging.debug = Initializer.debug
       Thin::Server.start('127.0.0.1', @port) do
         use Rack::Static,
           urls: %w(/css /js /img /doc),

--- a/lib/gitdocs/server.rb
+++ b/lib/gitdocs/server.rb
@@ -6,25 +6,22 @@ require 'gitdocs/settings_app'
 
 module Gitdocs
   class Server
-    def initialize(manager, port = 8888, repositories)
-      @manager      = manager
-      @port         = port.to_i
-      @repositories = repositories
+    def initialize(manager, port)
+      @manager = manager
+      @port    = port.to_i
     end
 
-    def self.start_and_wait(manager, override_port, repositories)
+    def self.start_and_wait(manager, override_port)
       return false unless Configuration.start_web_frontend
 
       web_port = override_port || Configuration.web_frontend_port
-      server = Server.new(manager, web_port, repositories)
+      server = Server.new(manager, web_port)
       server.start
       server.wait_for_start
       true
     end
 
     def start
-      BrowserApp.set :repositories, @repositories
-
       Thin::Logging.debug = @manager.debug
       Thin::Server.start('127.0.0.1', @port) do
         use Rack::Static,

--- a/lib/gitdocs/server.rb
+++ b/lib/gitdocs/server.rb
@@ -10,7 +10,7 @@ module Gitdocs
       @manager      = manager
       @port         = port.to_i
       @repositories = repositories
-      @search       = Gitdocs::Search.new(repositories)
+      @search       = Search.new(repositories)
     end
 
     def self.start_and_wait(manager, override_port, repositories)
@@ -24,7 +24,7 @@ module Gitdocs
     end
 
     def start
-      Gitdocs::BrowserApp.set :repositories, @repositories
+      BrowserApp.set :repositories, @repositories
 
       Thin::Logging.debug = @manager.debug
       Thin::Server.start('127.0.0.1', @port) do
@@ -33,8 +33,8 @@ module Gitdocs
           root: File.expand_path('../public', __FILE__)
         use Rack::MethodOverride
 
-        map('/settings') { run Gitdocs::SettingsApp }
-        map('/') { run Gitdocs::BrowserApp }
+        map('/settings') { run SettingsApp }
+        map('/') { run BrowserApp }
       end
     end
 

--- a/lib/gitdocs/server.rb
+++ b/lib/gitdocs/server.rb
@@ -10,7 +10,6 @@ module Gitdocs
       @manager      = manager
       @port         = port.to_i
       @repositories = repositories
-      @search       = Search.new(repositories)
     end
 
     def self.start_and_wait(manager, override_port, repositories)

--- a/lib/gitdocs/settings_app.rb
+++ b/lib/gitdocs/settings_app.rb
@@ -10,18 +10,20 @@ module Gitdocs
     get('/') do
       haml(
         :settings,
-        locals: { conf: settings.manager, nav_state: 'settings' }
+        locals: { nav_state: 'settings' }
       )
     end
 
     post('/') do
-      settings.manager.update_all(request.POST)
+      Configuration.update(request.POST['config'])
+      Share.update_all(request.POST['share'])
+      EM.add_timer(0.1) { Gitdocs.restart }
       redirect to('/')
     end
 
     delete('/:id') do
       id = params[:id].to_i
-      halt(404) unless settings.manager.remove_by_id(id)
+      halt(404) unless Share.remove_by_id(id)
       redirect to('/')
     end
   end

--- a/lib/gitdocs/share.rb
+++ b/lib/gitdocs/share.rb
@@ -1,0 +1,50 @@
+# -*- encoding : utf-8 -*-
+
+require 'active_record'
+
+class Gitdocs::Share < ActiveRecord::Base
+  # @param [#to_i] index
+  #
+  # @return [Share]
+  def self.at(index)
+    all[index.to_i]
+  end
+
+  # @param [String] path
+  def self.create_by_path!(path)
+    new(path: File.expand_path(path)).save!
+  end
+
+  # @param [Hash] updated_shares
+  # @return [void]
+  def self.update_all(updated_shares)
+    updated_shares.each do |index, share_config|
+      # Skip the share update if there is no path specified.
+      next unless share_config['path'] && !share_config['path'].empty?
+
+      # Split the remote_branch into remote and branch
+      remote_branch = share_config.delete('remote_branch')
+      share_config['remote_name'], share_config['branch_name'] =
+        remote_branch.split('/', 2) if remote_branch
+
+      at(index).update_attributes(share_config)
+    end
+  end
+
+  # @param [Integer] id of the share to remove
+  #
+  # @return [true] share was deleted
+  # @return [false] share does not exist
+  def self.remove_by_id(id)
+    find(id).destroy
+    true
+  rescue ActiveRecord::RecordNotFound
+    false
+  end
+
+  # @param [String] path of the share to remove
+  # @return [void]
+  def self.remove_by_path(path)
+    where(path: File.expand_path(path)).destroy_all
+  end
+end

--- a/lib/gitdocs/views/dir.haml
+++ b/lib/gitdocs/views/dir.haml
@@ -1,6 +1,6 @@
 - @title = root
 
-= haml(:_header, locals: { file: false, idx: idx })
+= haml(:_header, locals: { file: false })
 
 - if contents && contents.any?
   %table#fileListing.condensed-table.zebra-striped

--- a/lib/gitdocs/views/edit.haml
+++ b/lib/gitdocs/views/edit.haml
@@ -1,6 +1,6 @@
 - @title = root
 
-= haml(:_header, locals: { file: true, idx: idx })
+= haml(:_header, locals: { file: true })
 
 %form.edit{ method: 'POST', style: 'display:none;' }
   #editor

--- a/lib/gitdocs/views/file.haml
+++ b/lib/gitdocs/views/file.haml
@@ -1,6 +1,6 @@
 - @title = root
 
-= haml(:_header, locals: { file: true, idx: idx })
+= haml(:_header, locals: { file: true })
 
 .contents
   = preserve contents

--- a/lib/gitdocs/views/home.haml
+++ b/lib/gitdocs/views/home.haml
@@ -3,8 +3,8 @@
 %p Select a share to browse:
 
 %table#shares
-  - shares.each_with_index do |share, idx|
+  - Gitdocs::Share.all.each_with_index do |share, idx|
     %tr
       %td
         %a{ href: "/#{idx}" }
-          = share.root
+          = share.path

--- a/lib/gitdocs/views/home.haml
+++ b/lib/gitdocs/views/home.haml
@@ -3,8 +3,8 @@
 %p Select a share to browse:
 
 %table#shares
-  - Gitdocs::Share.all.each_with_index do |share, idx|
+  - Gitdocs::Share.all.each do |share|
     %tr
       %td
-        %a{ href: "/#{idx}" }
+        %a{ href: "/#{share.id}" }
           = share.path

--- a/lib/gitdocs/views/revisions.haml
+++ b/lib/gitdocs/views/revisions.haml
@@ -1,6 +1,6 @@
 - @title = root
 
-= haml(:_header, locals: { file: true, idx: idx })
+= haml(:_header, locals: { file: true })
 
 - if revisions && revisions.any?
   %table#revisions.condensed-table.zebra-striped

--- a/lib/gitdocs/views/settings.haml
+++ b/lib/gitdocs/views/settings.haml
@@ -7,9 +7,9 @@
     %dl
       %dt Web Frontend Port
       %dd
-        %input{ type: 'input', name: 'config[web_frontend_port]', value: conf.web_frontend_port }
+        %input{ type: 'input', name: 'config[web_frontend_port]', value: Gitdocs::Configuration.web_frontend_port }
   %h2 Shares
-  - conf.shares.each_with_index do |share, idx|
+  - Gitdocs::Share.all.each_with_index do |share, idx|
     .share{ id: "share-#{idx}", class: idx.even? ? 'even' : 'odd' }
       %dl
         %dt Path

--- a/test/integration/test_helper.rb
+++ b/test/integration/test_helper.rb
@@ -90,8 +90,8 @@ module Helper
   end
 
   def start_daemon
-    configuration = Gitdocs::Configuration.new
-    configuration.shares.each do |share|
+    Gitdocs::Initializer.initialize_database
+    Gitdocs::Share.all.each do |share|
       share.update_attributes(polling_interval: 0.1, notification: false)
     end
 

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -2,81 +2,19 @@
 
 require File.expand_path('../test_helper', __FILE__)
 
-describe 'gitdocs configuration' do
+describe Gitdocs::Configuration do
   before do
-    ENV['TEST'] = 'true'
-    ShellTools.capture { @config = Gitdocs::Configuration.new('/tmp/gitdocs') }
+    ShellTools.capture { Gitdocs::Initializer.initialize_database }
   end
 
-  it 'has sensible default config root' do
-    assert_equal '/tmp/gitdocs', @config.config_root
-  end
-
-  it 'can retrieve empty shares' do
-    assert_equal [], @config.shares
-  end
-
-  it 'can have a path added' do
-    @config.add_path('/my/../my/path') # normalized test
-    assert_equal '/my/path', @config.shares.first.path
-    assert_equal 15.0, @config.shares.first.polling_interval
-  end
-
-  it 'can have a path removed' do
-    @config.add_path('/my/path')
-    @config.add_path('/my/path/2')
-    @config.remove_path('/my/../my/path/2') # normalized test
-    assert_equal ['/my/path'], @config.shares.map(&:path)
-  end
-
-  it 'can have a share removed by id' do
-    @config.add_path('/my/path')
-    @config.add_path('/my/path/2')
-
-    # Delete an index which exists
-    @config.remove_by_id(2).must_equal(true) # normalized test
-    assert_equal ['/my/path'], @config.shares.map(&:path)
-
-    # Try to delete an index which does not exist
-    @config.remove_by_id(5).must_equal(false) # normalized test
-    assert_equal ['/my/path'], @config.shares.map(&:path)
-  end
-
-  it 'can clear paths' do
-    @config.add_path('/my/path')
-    @config.add_path('/my/path/2')
-    @config.clear
-    assert_equal [], @config.shares.map(&:path)
-  end
-
-  describe '#update_all' do
+  describe 'Config.update' do
     before do
-      @config.add_path('/my/path')
-      @config.add_path('/my/path/2')
-      @config.add_path('/my/path/3')
-      @config.add_path('/my/path/4')
-      @config.add_path('/my/path/5')
-      @config.update_all(
-        'config' => { 'start_web_frontend' => false, 'web_frontend_port' => 9999 },
-        'share'  => {
-          '0' => { 'path' => '/my/path',    'polling_interval' => 42 },
-          '1' => { 'path' => '/my/path/2',  'polling_interval' => 66 },
-          '2' => { 'path' => '/my/path/3a', 'polling_interval' => 77 },
-          '3' => { 'path' => '',            'polling_interval' => 88 },
-          '4' => {                          'polling_interval' => 99 }
-        }
+      Gitdocs::Configuration.update(
+        'start_web_frontend' => false, 'web_frontend_port' => 9999
       )
     end
-    it { @config.shares.size.must_equal(5) }
-    it { @config.shares[0].path.must_equal('/my/path') }
-    it { @config.shares[0].polling_interval.must_equal(42) }
-    it { @config.shares[1].path.must_equal('/my/path/2') }
-    it { @config.shares[1].polling_interval.must_equal(66) }
-    it { @config.shares[2].path.must_equal('/my/path/3a') }
-    it { @config.shares[2].polling_interval.must_equal(77) }
-    it { @config.shares[3].path.must_equal('/my/path/4') }
-    it { @config.shares[3].polling_interval.must_equal(15) }
-    it { @config.shares[4].path.must_equal('/my/path/5') }
-    it { @config.shares[4].polling_interval.must_equal(15) }
+
+    it { Gitdocs::Configuration.start_web_frontend.must_equal(false) }
+    it { Gitdocs::Configuration.web_frontend_port.must_equal(9999) }
   end
 end

--- a/test/unit/repository_committer_test.rb
+++ b/test/unit/repository_committer_test.rb
@@ -1,0 +1,181 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path('../test_helper', __FILE__)
+
+describe Gitdocs::Repository::Committer do
+
+  before do
+    FileUtils.rm_rf('tmp/unit')
+#    mkdir
+#    repo = Rugged::Repository.init_at('tmp/unit/local')
+#    repo.config['user.email'] = 'afish@example.com'
+#    repo.config['user.name']  = 'Art T. Fish'
+  end
+
+  let(:root_dirname) { 'tmp/unit/local' }
+  let(:committer)    { Gitdocs::Repository::Committer.new(root_dirname) }
+  let(:local_repo)   { Rugged::Repository.new(root_dirname) }
+  let(:author1)      { 'Art T. Fish <afish@example.com>' }
+
+  describe 'initialize' do
+    subject { committer }
+
+    describe 'when directory missing' do
+      it { assert_raises(Gitdocs::Repository::InvalidError) { subject } }
+    end
+
+    describe 'when not a repository' do
+      before { mkdir }
+      it { assert_raises(Gitdocs::Repository::InvalidError) { subject } }
+    end
+
+    describe 'when valid repository' do
+      before { init_at }
+      it { subject.must_be_kind_of Gitdocs::Repository::Committer }
+    end
+  end
+
+  describe '#commit' do
+    subject { committer.commit }
+    before { init_at }
+
+    # TODO: should test the paths which use the message file
+
+    describe 'no previous commits' do
+      describe 'nothing to commit' do
+        it { subject.must_equal false }
+      end
+
+      describe 'changes to commit' do
+        before do
+          write('file1', 'foobar')
+          mkdir('directory')
+        end
+        it { subject.must_equal true }
+
+        describe 'side effects' do
+          before { subject }
+          it { local_file_exist?('directory/.gitignore').must_equal true }
+          it { commit_count(local_repo).must_equal 1 }
+          it { head_commit(local_repo).message.must_equal "Auto-commit from gitdocs\n" }
+          it { local_repo_clean?.must_equal true }
+        end
+      end
+    end
+
+    describe 'previous commits' do
+      before do
+        write_and_commit('file1', 'foobar', 'initial commit', author1)
+        write_and_commit('file2', 'deadbeef', 'second commit', author1)
+      end
+
+      describe 'nothing to commit' do
+        it { subject.must_equal false }
+      end
+
+      describe 'changes to commit' do
+        before do
+          write('file1', 'foobar')
+          rm_rf('file2')
+          write('file3', 'foobar')
+          mkdir('directory')
+        end
+        it { subject.must_equal true }
+
+        describe 'side effects' do
+          before { subject }
+          it { local_file_exist?('directory/.gitignore').must_equal true }
+          it { commit_count(local_repo).must_equal 3 }
+          it { head_commit(local_repo).message.must_equal "Auto-commit from gitdocs\n" }
+          it { local_repo_clean?.must_equal true }
+        end
+      end
+    end
+  end
+
+  describe '#write_commit_message' do
+    subject { result = committer.write_commit_message(commit_message) ; puts result; result}
+
+    before do
+      init_at
+      subject
+    end
+
+    describe 'with no message' do
+      let(:commit_message) { nil }
+      it { local_file_exist?('.gitmessage~').must_equal(false) }
+    end
+
+    describe 'with empty message' do
+      let(:commit_message) { '' }
+      it { local_file_exist?('.gitmessage~').must_equal(false) }
+    end
+
+    describe 'with message' do
+      let(:commit_message) { 'foobar' }
+      it { local_file_content('.gitmessage~').must_equal('foobar') }
+    end
+  end
+
+  ##############################################################################
+
+  private
+
+  def rm_rf(filename)
+    FileUtils.rm_rf(File.join(root_dirname, filename))
+  end
+
+  def init_at
+    mkdir
+    repo = Rugged::Repository.init_at(root_dirname)
+    repo.config['user.email'] = 'afish@example.com'
+    repo.config['user.name']  = 'Art T. Fish'
+  end
+
+  def mkdir(*path)
+    FileUtils.mkdir_p(File.join(root_dirname, *path))
+  end
+
+  def write(filename, content)
+    mkdir(File.dirname(filename))
+    File.write(File.join(root_dirname, filename), content)
+  end
+
+  def local_file_exist?(*path_elements)
+    File.exist?(File.join(root_dirname, *path_elements))
+  end
+
+  def head_commit(repo)
+    walker = Rugged::Walker.new(repo)
+    walker.push(repo.head.target)
+    walker.first
+  rescue Rugged::ReferenceError
+    # The repo does not have a head => no commits => no head commit.
+    nil
+  end
+
+  def commit_count(repo)
+    walker = Rugged::Walker.new(repo)
+    walker.push(repo.head.target)
+    walker.count
+  rescue Rugged::ReferenceError
+    # The repo does not have a head => no commits.
+    0
+  end
+
+  def local_repo_clean?
+    local_repo.diff_workdir(local_repo.head.target, include_untracked: true).deltas.empty?
+  end
+
+  def local_file_content(*path_elements)
+    return nil unless local_file_exist?
+    File.read(File.join(root_dirname, *path_elements))
+  end
+
+  # @return [String] commit oid
+  def write_and_commit(filename, content, commit_msg, author)
+    mkdir(File.dirname(filename))
+    File.write(File.join(root_dirname, filename), content)
+    `cd #{root_dirname} ; git add #{filename}; git commit -m '#{commit_msg}' --author='#{author}'`
+    `cd #{root_dirname} ; git rev-parse HEAD`.strip
+  end
+end

--- a/test/unit/repository_path_test.rb
+++ b/test/unit/repository_path_test.rb
@@ -20,8 +20,7 @@ describe Gitdocs::Repository::Path do
   end
 
   describe '#write' do
-    subject { path.write('foobar', :message) }
-    before { repository.expects(:write_commit_message).with(:message) }
+    subject { path.write('foobar') }
 
     describe 'directory missing' do
       before { subject }
@@ -342,7 +341,7 @@ describe Gitdocs::Repository::Path do
 
     describe 'blob present' do
       let(:blob) { stub(text: 'deadbeef') }
-      before { path.expects(:write).with('deadbeef', "Reverting '#{relative_path}' to ref") }
+      before { path.expects(:write).with('deadbeef') }
       it { subject }
     end
   end

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -21,6 +21,8 @@ describe 'gitdocs runner' do
   describe '#sync_changes' do
     subject { runner.sync_changes }
 
+    before { repository.expects(:valid?).returns(true) }
+
     describe 'fetch sync' do
       before do
         share.stubs(:sync_type).returns('fetch')

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -2,6 +2,19 @@
 require File.expand_path('../test_helper', __FILE__)
 
 describe Gitdocs::Search do
+  describe '.search' do
+    subject { Gitdocs::Search.search(:term) }
+    before do
+      Gitdocs::Share.stubs(:all).returns([:share1, :share2])
+      Gitdocs::Repository.stubs(:new).with(:share1).returns(:repository1)
+      Gitdocs::Repository.stubs(:new).with(:share2).returns(:repository2)
+      Gitdocs::Search.stubs(:new).with([:repository1, :repository2])
+        .returns(search = mock)
+      search.stubs(:search).with(:term).returns(:result)
+    end
+    it { subject.must_equal(:result) }
+  end
+
   describe 'initialize' do
     subject { Gitdocs::Search.new(:repositories) }
     it { subject.instance_variable_get(:@repositories).must_equal :repositories }

--- a/test/unit/share_test.rb
+++ b/test/unit/share_test.rb
@@ -1,0 +1,68 @@
+# -*- encoding : utf-8 -*-
+
+require File.expand_path('../test_helper', __FILE__)
+
+describe Gitdocs::Share do
+  before do
+    ShellTools.capture { Gitdocs::Initializer.initialize_database }
+  end
+
+  it 'can retrieve empty shares' do
+    assert_equal [], Gitdocs::Share.all.to_a
+  end
+
+  it 'can have a path added' do
+    Gitdocs::Share.create_by_path!('/my/../my/path') # normalized test
+    assert_equal '/my/path', Gitdocs::Share.at(0).path
+    assert_equal 15.0, Gitdocs::Share.at(0).polling_interval
+  end
+
+  it 'can have a path removed' do
+    Gitdocs::Share.create_by_path!('/my/path')
+    Gitdocs::Share.create_by_path!('/my/path/2')
+    Gitdocs::Share.remove_by_path('/my/../my/path/2') # normalized test
+    assert_equal ['/my/path'], Gitdocs::Share.all.map(&:path)
+  end
+
+  it 'can have a share removed by id' do
+    Gitdocs::Share.create_by_path!('/my/path')
+    Gitdocs::Share.create_by_path!('/my/path/2')
+
+    # Delete an index which exists
+    Gitdocs::Share.remove_by_id(2).must_equal(true) # normalized test
+    assert_equal ['/my/path'], Gitdocs::Share.all.map(&:path)
+
+    # Try to delete an index which does not exist
+    Gitdocs::Share.remove_by_id(5).must_equal(false) # normalized test
+    assert_equal ['/my/path'], Gitdocs::Share.all.map(&:path)
+  end
+
+  describe '#update_all' do
+    before do
+      Gitdocs::Share.create_by_path!('/my/path')
+      Gitdocs::Share.create_by_path!('/my/path/2')
+      Gitdocs::Share.create_by_path!('/my/path/3')
+      Gitdocs::Share.create_by_path!('/my/path/4')
+      Gitdocs::Share.create_by_path!('/my/path/5')
+
+      Gitdocs::Share.update_all(
+        '0' => { 'path' => '/my/path',    'polling_interval' => 42 },
+        '1' => { 'path' => '/my/path/2',  'polling_interval' => 66 },
+        '2' => { 'path' => '/my/path/3a', 'polling_interval' => 77 },
+        '3' => { 'path' => '',            'polling_interval' => 88 },
+        '4' => {                          'polling_interval' => 99 }
+      )
+    end
+    it { Gitdocs::Share.all.size.must_equal(5) }
+    it do
+      Gitdocs::Share.all.map(&:path).must_equal(
+        %w(/my/path /my/path/2 /my/path/3a /my/path/4 /my/path/5)
+      )
+    end
+    it do
+      Gitdocs::Share.all.map(&:polling_interval).must_equal(
+        [42, 66, 77, 15, 15]
+      )
+    end
+  end
+end

--- a/test/unit/test_helper.rb
+++ b/test/unit/test_helper.rb
@@ -6,5 +6,8 @@ $LOAD_PATH.unshift File.expand_path('../../lib')
 require 'gitdocs'
 require 'mocha/setup'
 
+Gitdocs::Initializer.root_dirname = '/tmp/gitdocs'
+Gitdocs::Initializer.database     = ':memory:'
+
 require 'coveralls'
 Coveralls.wear!


### PR DESCRIPTION
In the process of doing the Celluloid conversion, I found that passing around the Configuration, Manager, and Repositories objects makes things more complicated. I am trying to re-write these class to either:
* use more class methods (more like ActiveRecord)
* initialize class where they are used, instead of passing them around

So, far I have start with making the ActiveRecord access more direct and to stop passing around the Configuration object.

I have more changes to come, and I would appreciate any feedback.