### PR TITLE
Upgrading and cleaning up gem dependencies

### DIFF
--- a/gitdocs.gemspec
+++ b/gitdocs.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'poltergeist',            '~> 1.6.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'mocha'
-  s.add_development_dependency 'metric_fu'
   s.add_development_dependency 'aruba',                  '~> 0.6.1'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'haml-lint',              '~> 0.10.0'

--- a/gitdocs.gemspec
+++ b/gitdocs.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'redcarpet',       '~> 3.3.0'
   s.add_dependency 'thor',            '~> 0.14.6'
   s.add_dependency 'coderay',         '~> 1.1.0'
-  s.add_dependency 'dante',           '~> 0.1.2'
+  s.add_dependency 'dante',           '~> 0.2.0'
   s.add_dependency 'growl',           '~> 1.0.3'
   s.add_dependency 'haml',            '~> 4.0.5'
   s.add_dependency 'sqlite3',         '~> 1.3.4'

--- a/gitdocs.gemspec
+++ b/gitdocs.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'sqlite3',         '~> 1.3.4'
   s.add_dependency 'activerecord',    '~> 4.2.0'
   s.add_dependency 'grit',            '~> 2.5.0'
-  s.add_dependency 'shell_tools',     '~> 0.1.0'
   s.add_dependency 'mimetype-fu',     '~> 0.1.2'
   s.add_dependency 'eventmachine',    '>= 1.0.3'
   s.add_dependency 'launchy',         '~> 2.4.2'
@@ -44,6 +43,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'minitest',               '~> 5.5.0'
   s.add_development_dependency 'capybara_minitest_spec', '~> 1.0.2'
+  s.add_development_dependency 'shell_tools',            '~> 0.1.0'
   s.add_development_dependency 'poltergeist',            '~> 1.6.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'mocha'

--- a/gitdocs.gemspec
+++ b/gitdocs.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'poltergeist',            '~> 1.6.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'mocha'
-  s.add_development_dependency 'fakeweb'
   s.add_development_dependency 'metric_fu'
   s.add_development_dependency 'aruba',                  '~> 0.6.1'
   s.add_development_dependency 'rubocop'

--- a/lib/gitdocs.rb
+++ b/lib/gitdocs.rb
@@ -41,6 +41,11 @@ module Gitdocs
     @manager.stop
   end
 
+  # @return [String]
+  def self.log_path
+    File.expand_path('log', Initializer.root_dirname)
+  end
+
   # @param [String] message
   # @return [void]
   def self.log_debug(message)
@@ -77,7 +82,7 @@ module Gitdocs
       if Initializer.foreground
         STDOUT
       else
-        File.expand_path('log', Initializer.root_dirname)
+        log_path
       end
     @logger = Logger.new(output)
     @logger.level = Initializer.verbose ? Logger::DEBUG : Logger::INFO

--- a/lib/gitdocs.rb
+++ b/lib/gitdocs.rb
@@ -3,7 +3,6 @@
 require 'thread'
 require 'dante'
 require 'socket'
-require 'shell_tools'
 require 'guard'
 require 'grit'
 require 'rugged'

--- a/lib/gitdocs/cli.rb
+++ b/lib/gitdocs/cli.rb
@@ -150,7 +150,8 @@ module Gitdocs
           'gitdocs',
           debug:     false,
           daemonize: true,
-          pid_path: pid_path
+          pid_path:  pid_path,
+          log_path:  Gitdocs.log_path
         )
       end
 

--- a/test/integration/browse_test.rb
+++ b/test/integration/browse_test.rb
@@ -15,9 +15,8 @@ describe 'browse and edit repository file through the UI' do
     GitFactory.commit(:local, 'README.md', 'hello i am a README')
 
     gitdocs_start
+    visit_and_click_link('Home')
 
-    visit 'http://localhost:7777/'
-    click_link('Home')
     within('table#shares') do
       within('tbody') do
         click_link(abs_current_dir('local'))

--- a/test/integration/full_sync_test.rb
+++ b/test/integration/full_sync_test.rb
@@ -63,34 +63,21 @@ end
 
 ################################################################################
 
-def wait_for(&block)
-  Timeout.timeout(Capybara.default_max_wait_time) do
-    begin
-      block.call
-    rescue Minitest::Assertion
-      sleep(0.1)
-      retry
-    end
-  end
-rescue Timeout::Error
-  block.call
-end
-
 # @param (see GitInspector.clean?)
 def assert_clean(repo_name)
-  wait_for { GitInspector.clean?(repo_name).must_equal(true) }
+  wait_for_assert { GitInspector.clean?(repo_name).must_equal(true) }
 end
 
 # @param [#to_s] repo_name
 # @param [String] filename
 # @param [String] content
 def assert_file_content(repo_name, filename, content)
-  wait_for do
+  wait_for_assert do
     GitInspector.file_content(repo_name, filename).must_equal(content)
   end
 end
 
 # @param (see GitInspector.file_exist?)
 def assert_file_exist(repo_name, filename)
-  wait_for { GitInspector.file_exist?(repo_name, filename).must_equal(true) }
+  wait_for_assert { GitInspector.file_exist?(repo_name, filename).must_equal(true) }
 end

--- a/test/integration/share_management_test.rb
+++ b/test/integration/share_management_test.rb
@@ -15,8 +15,7 @@ describe 'Manage which shares are being watched' do
   it 'should update a share through the UI' do
     gitdocs_add('local')
     gitdocs_start
-    visit('http://localhost:7777/')
-    click_link('Settings')
+    visit_and_click_link('Settings')
 
     within('#settings') do
       within('#share-0') do
@@ -49,8 +48,7 @@ describe 'Manage which shares are being watched' do
 
     it 'through UI' do
       gitdocs_start
-      visit('http://localhost:7777/')
-      click_link('Settings')
+      visit_and_click_link('Settings')
 
       within('#settings') do
         within('#share-0') { click_link('Delete') }

--- a/test/integration/test_helper.rb
+++ b/test/integration/test_helper.rb
@@ -191,6 +191,41 @@ module Helper
       assert_no_partial_output(not_expected_output, output_from(command))
     end
   end
+
+  # @overload wait_for_assert
+  #   @yield to a block which executes Minitest assertion
+  #
+  # @overload wait_for_assert(interval)
+  #   @param [Float] interval
+  #   @yield to a block which executes Minitest assertion
+  #
+  # @raise [Minitest::Assertion]
+  #
+  # @return [void]
+  def wait_for_assert(interval = 0.1)
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      begin
+        yield
+      rescue Minitest::Assertion, Capybara::Poltergeist::Error
+        sleep(interval)
+        retry
+      end
+    end
+  rescue Timeout::Error
+    yield
+  end
+
+  # @param [String] locator
+  #
+  # @raise [Minitest::Assertion]
+  #
+  # @return [void]
+  def visit_and_click_link(locator)
+    wait_for_assert do
+      visit('http://localhost:7777/')
+      click_link(locator)
+    end
+  end
 end
 
 class MiniTest::Spec

--- a/test/integration/test_helper.rb
+++ b/test/integration/test_helper.rb
@@ -156,11 +156,14 @@ module Helper
     gitdocs_command('add', path, "Added path #{path} to doc list")
   end
 
-  # @deprecated
-  # @param [String] remote_repository_path
   # @param [Array<String>] destination_paths
-  def gitdocs_create(remote_repository_path, *destination_paths)
-    destination_paths.each do |destination_path|
+  #
+  # @return [void]
+  def gitdocs_create_from_remote(*destination_paths)
+    full_destination_paths = destination_paths.map { |x| GitFactory.expand_path(x) }
+    remote_repository_path = GitFactory.init_bare(:remote)
+
+    full_destination_paths.each do |destination_path|
       gitdocs_command(
         'create',
         "#{destination_path} #{remote_repository_path}",
@@ -169,15 +172,9 @@ module Helper
     end
   end
 
-  # @param [Array<String>] destination_paths
+  # @param [Array<String>] expected_outputs
   #
   # @return [void]
-  def gitdocs_create_from_remote(*destination_paths)
-    full_destination_paths = destination_paths.map { |x| GitFactory.expand_path(x) }
-    remote_repository_path = GitFactory.init_bare(:remote)
-    gitdocs_create(remote_repository_path, *full_destination_paths)
-  end
-
   def gitdocs_assert_status_contains(*expected_outputs)
     command = gitdocs_command('status', '', Gitdocs::VERSION)
     expected_outputs.each do |expected_output|
@@ -185,6 +182,9 @@ module Helper
     end
   end
 
+  # @param [Array<String>] not_expected_outputs
+  #
+  # @return [void]
   def gitdocs_assert_status_not_contain(*not_expected_outputs)
     command = gitdocs_command('status', '', Gitdocs::VERSION)
     not_expected_outputs.each do |not_expected_output|

--- a/test/support/git_factory.rb
+++ b/test/support/git_factory.rb
@@ -209,11 +209,7 @@ module GitInspector
       repo.diff_workdir(
         repo.head.target, include_untracked: true
       ).deltas.empty?
-    rescue Rugged::ReferenceError
-      false
-    rescue Rugged::InvalidError
-      false
-    rescue Rugged::RepositoryError
+    rescue Rugged::Error
       false
     end
 

--- a/test/unit/test_helper.rb
+++ b/test/unit/test_helper.rb
@@ -5,6 +5,8 @@ require 'minitest/autorun'
 $LOAD_PATH.unshift File.expand_path('../../lib')
 require 'gitdocs'
 require 'mocha/setup'
+require 'shell_tools'
+
 Dir.glob(File.expand_path('../../support/**/*.rb', __FILE__)).each do |filename|
   require_relative filename
 end


### PR DESCRIPTION
* upgraded Dante to v0.2.0
* removed metric_fu and fakeweb, because they are not being used
* changed shell_tools to a development dependency, because it is only used in tests
* improved the test suite with some better error handling, timing, and documentation. Hopefully, these might help TravisCI be more reliable too