### PR TITLE
Update haml-lint gem to haml_lint

### DIFF
--- a/gitdocs.gemspec
+++ b/gitdocs.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha',                  '~> 1.1.0'
   s.add_development_dependency 'aruba',                  '~> 0.6.1'
   s.add_development_dependency 'rubocop',                '~> 0.34.2'
-  s.add_development_dependency 'haml-lint',              '~> 0.13.0'
+  s.add_development_dependency 'haml_lint',              '~> 0.13.0'
   s.add_development_dependency 'jslint_on_rails',        '~> 1.1.1'
   s.add_development_dependency 'shotgun',                '~> 0.9.1'
   s.add_development_dependency 'codeclimate-test-reporter'

--- a/lib/gitdocs/cli.rb
+++ b/lib/gitdocs/cli.rb
@@ -78,10 +78,12 @@ module Gitdocs
       restart if running?
     end
 
+    method_option :pid, type: :string, aliases: '-P'
     desc 'clear', 'Clears all paths from gitdocs'
     def clear
       Share.destroy_all
       say 'Cleared paths from gitdocs'
+      restart if running?
     end
 
     method_option :pid, type: :string, aliases: '-P'


### PR DESCRIPTION
Haml lint was updated to better match the rspec naming conventions.
http://guides.rubygems.org/name-your-gem/

But they also yanked the old gems, which will cause a brand new install
to fail. (Or the fresh install on TravisCI.)