### PR TITLE
Update version and CHANGLOG to 0.6.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
-0.6.1
+0.6.2
+
+ * add dependencies on tilt and celluloid-io to ensure correct install (@acant)
+
+0.6.1 (June 11th 2016)
 
  * fix stop command from hanging the daemon instead of stopping (@acant)
 

--- a/lib/gitdocs/version.rb
+++ b/lib/gitdocs/version.rb
@@ -1,3 +1,3 @@
 module Gitdocs
-  VERSION = '0.6.1'.freeze
+  VERSION = '0.6.2'.freeze
 end


### PR DESCRIPTION
I should have included this in my last PR, but once this is merged it would be good to release v0.6.2. That will hopefully avoid others ending up with dependency problems related to tilt and celluloid-io.