### PR TITLE
Add a configurable web host name

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This browser front-end supports the following features:
  * Upload and create new files within your shares
  * Manage share settings and other configuration options
 
-To check out the front-end, simply visit `http://localhost:8888` whenever gitdocs is running.
+To check out the front-end, simply visit `http://127.0.0.1:8888` whenever gitdocs is running.
 
 ### Conflict Resolution
 

--- a/lib/gitdocs/cli.rb
+++ b/lib/gitdocs/cli.rb
@@ -15,6 +15,7 @@ module Gitdocs
     desc 'start', 'Starts a daemonized gitdocs process'
     method_option :foreground, type: :boolean, aliases: '-fg'
     method_option :verbose,    type: :boolean, aliases: '-v'
+    method_option :host,       type: :string,  aliases: '-h'
     method_option :port,       type: :string,  aliases: '-p'
     method_option :pid,        type: :string,  aliases: '-P'
     def start
@@ -28,12 +29,12 @@ module Gitdocs
       if options[:foreground]
         say 'Run in the foreground', :yellow
         Gitdocs::Initializer.foreground = true
-        Manager.start(web_port)
+        Manager.start(web_host, web_port)
       else
         # Clear the arguments so that they will not be processed by the
         # Dante execution.
         ARGV.clear
-        runner.execute { Manager.start(web_port) }
+        runner.execute { Manager.start(web_host, web_port) }
 
         if running?
           say 'Started gitdocs', :green
@@ -139,6 +140,7 @@ module Gitdocs
     end
 
     desc 'open', 'Open the Web UI'
+    method_option :host, type: :string, aliases: '-h'
     method_option :port, type: :string, aliases: '-p'
     def open
       unless running?
@@ -146,7 +148,7 @@ module Gitdocs
         return
       end
 
-      Launchy.open("http://localhost:#{web_port}/")
+      Launchy.open("http://#{web_host}:#{web_port}/")
     end
 
     # TODO: make this work
@@ -193,6 +195,13 @@ module Gitdocs
         result = options[:port]
         result ||= Configuration.web_frontend_port
         result.to_i
+      end
+
+      # @return [String]
+      def web_host
+        result = options[:host]
+        result ||= Configuration.web_frontend_host
+        result
       end
 
       # @param [String] path

--- a/lib/gitdocs/configuration.rb
+++ b/lib/gitdocs/configuration.rb
@@ -14,6 +14,11 @@ module Gitdocs
       Config.global.web_frontend_port
     end
 
+    # @return [String]
+    def self.web_frontend_host
+      Config.global.web_frontend_host
+    end
+
     # @param [Hash] new_config
     def self.update(new_config)
       Config.global.update_attributes(new_config)
@@ -23,10 +28,12 @@ module Gitdocs
     # database table. There are other ways to achieve this, but this seemed most
     # clear for now. [2015-06-26 -- acant]
     #
-    # @!attribute start_frontend_port
+    # @!attribute start_web_frontend
     #   @return [Boolean] defaults to true
     # @!attribute web_frontend_port
     #   @return [Integer] defaults to 8888
+    # @!attribute web_frontend_host
+    #   @return [String] defaults to '127.0.0.1'
     class Config < ActiveRecord::Base
       # @return [Gitdocs::Configuration::Config]
       def self.global

--- a/lib/gitdocs/manager.rb
+++ b/lib/gitdocs/manager.rb
@@ -21,9 +21,10 @@ module Gitdocs
       :notification
     end
 
-    # @param [Integer] web_port
+    # @param [String] host
+    # @param [Integer] port
     # @return [void]
-    def start(web_port)
+    def start(host, port)
       Gitdocs.log_info("Starting Gitdocs v#{VERSION}...")
       Gitdocs.log_info(
         "Using configuration root: '#{Initializer.root_dirname}'"
@@ -48,8 +49,8 @@ module Gitdocs
         args: [
           app,
           {
-            Host:  '127.0.0.1',
-            Port:  web_port,
+            Host:  host,
+            Port:  port,
             quiet: true
           }
         ]

--- a/lib/gitdocs/manager.rb
+++ b/lib/gitdocs/manager.rb
@@ -6,8 +6,8 @@ module Gitdocs
   class Manager
     # @param (see #start)
     # @return (see #start)
-    def self.start(web_port)
-      Manager.new.start(web_port)
+    def self.start(*args)
+      Manager.new.start(*args)
     end
 
     # @return [void]

--- a/lib/gitdocs/migration/008_add_web_host_to_config.rb
+++ b/lib/gitdocs/migration/008_add_web_host_to_config.rb
@@ -1,0 +1,11 @@
+# -*- encoding : utf-8 -*-
+
+class AddWebHostToConfig < ActiveRecord::Migration
+  def self.up
+    add_column :configs, :web_frontend_host, :string, default: '127.0.0.1'
+  end
+
+  def self.down
+    fail
+  end
+end

--- a/lib/gitdocs/views/settings.haml
+++ b/lib/gitdocs/views/settings.haml
@@ -5,6 +5,9 @@
   %h2 Gitdocs
   .field.config#config
     %dl
+      %dt Web Frontend Host
+      %dd
+        %input{ type: 'input', name: 'config[web_frontend_host]', value: Gitdocs::Configuration.web_frontend_host }
       %dt Web Frontend Port
       %dd
         %input{ type: 'input', name: 'config[web_frontend_port]', value: Gitdocs::Configuration.web_frontend_port }

--- a/test/integration/test_helper.rb
+++ b/test/integration/test_helper.rb
@@ -15,10 +15,10 @@ Dir.glob(File.expand_path('../../support/**/*.rb', __FILE__)).each do |filename|
   require_relative filename
 end
 
-Capybara.app_host              = 'http://localhost:7777/'
+Capybara.app_host              = 'http://127.0.0.1:7777/'
 Capybara.default_driver        = :poltergeist
 Capybara.run_server            = false
-Capybara.default_max_wait_time = ENV['TRAVIS'] ? 120 : 30
+Capybara.default_max_wait_time = ENV['TRAVIS'] ? 120 : 120
 
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(
@@ -170,7 +170,11 @@ module Helper
   # @return [void]
   def gitdocs_start
     FileUtils.rm_rf(PID_FILE)
-    gitdocs_command('start', '--verbose', '--port=7777', 'Started gitdocs')
+    gitdocs_command(
+      'start',
+      '--verbose', '--host=127.0.0.1', '--port=7777',
+      'Started gitdocs'
+    )
   end
 
   # @overload abs_current_dir
@@ -261,7 +265,7 @@ module Helper
   # @return [void]
   def visit_and_click_link(locator)
     wait_for_assert(1) do
-      visit('http://localhost:7777/')
+      visit('http://127.0.0.1:7777/')
       click_link(locator)
     end
   end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -10,11 +10,14 @@ describe Gitdocs::Configuration do
   describe 'Config.update' do
     before do
       Gitdocs::Configuration.update(
-        'start_web_frontend' => false, 'web_frontend_port' => 9999
+        start_web_frontend: false,
+        web_frontend_port:  9999,
+        web_frontend_host:  'example.com'
       )
     end
 
     it { Gitdocs::Configuration.start_web_frontend.must_equal(false) }
     it { Gitdocs::Configuration.web_frontend_port.must_equal(9999) }
+    it { Gitdocs::Configuration.web_frontend_host.must_equal('example.com') }
   end
 end

--- a/test/unit/manager_test.rb
+++ b/test/unit/manager_test.rb
@@ -4,11 +4,11 @@ require File.expand_path('../test_helper', __FILE__)
 
 describe 'Gitdocs::Manager' do
   describe '.start' do
-    subject { Gitdocs::Manager.start(:web_port) }
+    subject { Gitdocs::Manager.start(:arg1, :arg2, :arg3) }
 
     before do
       Gitdocs::Manager.stubs(:new).returns(manager = stub)
-      manager.expects(:start).with(:web_port)
+      manager.expects(:start).with(:arg1, :arg2, :arg3)
     end
 
     it { subject }


### PR DESCRIPTION
Really a re-implementation of PR#107, accounting for the significant changes to the underlying code since that PR was originally opened.

The change will allow the host name to be configured, but will still default to 127.0.0.1.