### PR TITLE
Limiting the nior4 dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ sudo: false
 addons:
   code_climate:
     repo_token: "18995229639977d370a4adf13644223c53baa31b9c7fc302a7ce263aa5bc6dbf"
+after_success:
+  - bundle exec codeclimate-test-reporter

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,9 @@
-0.6.2
+0.6.3
+
+ * fix gem dependencies to preserve Ruby v2.0.0 compatibility (@acant)
+ * add --host flag for setting the address for the web interface (@acant)
+
+0.6.2 (July 5th 2016)
 
  * add dependencies on tilt and celluloid-io to ensure correct install (@acant)
 

--- a/gitdocs.gemspec
+++ b/gitdocs.gemspec
@@ -38,6 +38,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri',        '~> 1.6.8'
 
   s.add_dependency 'sinatra',         '~> 1.4.5'
+  # FIXME: Sinatra v1.4 appears to be incompatible with Rack >2, so it needs to
+  # be explicitly limited. This will likely be resolved with Sinatra v2.
+  s.add_dependency 'rack',            '< 2.0'
   s.add_dependency 'redcarpet',       '~> 3.3.0'
   s.add_dependency 'thor',            '~> 0.19.1'
   s.add_dependency 'coderay',         '~> 1.1.0'

--- a/gitdocs.gemspec
+++ b/gitdocs.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'listen',          '~> 3.0.5'
   # FIXME: nior4 cannot be upgraded until we drop support for Ruby <v2.2.2
   s.add_dependency 'nio4r',           '~> 1.2.1'
+  # FIXME: nokoiri cannot be upgrade until we drop support for Ruby <v2.0.0
+  s.add_dependency 'nokogiri',        '~> 1.6.8'
 
   s.add_dependency 'sinatra',         '~> 1.4.5'
   s.add_dependency 'redcarpet',       '~> 3.3.0'

--- a/gitdocs.gemspec
+++ b/gitdocs.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'celluloid-io',    '~> 0.16.0'
   # FIXME: listen cannot be upgraded until we drop support for Ruby <v2.1
   s.add_dependency 'listen',          '~> 3.0.5'
+  # FIXME: nior4 cannot be upgraded until we drop support for Ruby <v2.2.2
+  s.add_dependency 'nio4r',           '~> 1.2.1'
 
   s.add_dependency 'sinatra',         '~> 1.4.5'
   s.add_dependency 'redcarpet',       '~> 3.3.0'

--- a/lib/gitdocs/version.rb
+++ b/lib/gitdocs/version.rb
@@ -1,3 +1,3 @@
 module Gitdocs
-  VERSION = '0.6.2'.freeze
+  VERSION = '0.6.3'.freeze
 end

--- a/test/unit/test_helper.rb
+++ b/test/unit/test_helper.rb
@@ -13,7 +13,6 @@ end
 require 'codeclimate-test-reporter'
 SimpleCov.add_filter 'test'
 SimpleCov.start
-CodeClimate::TestReporter.start
 
 # Load and configure the real code #############################################
 require 'gitdocs'


### PR DESCRIPTION
The nior4 gem is a dependency from celluloid-io, and the very latest
version of nio4r only supports Ruby >2.2.2. In order to preserve 2.0.0
support for nio4r will be limit.

A note is included that this should be removed when we change our
required Ruby version to >2.2.2.